### PR TITLE
Use string concatenation instead of array.join for performance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@ parserOptions:
 env:
     es6: true
     browser: true
+    node: true
 
 extends:
     "eslint:recommended"

--- a/src/path.js
+++ b/src/path.js
@@ -6,7 +6,7 @@ var pi = Math.PI,
 function Path() {
   this._x0 = this._y0 = // start of current subpath
   this._x1 = this._y1 = null; // end of current subpath
-  this._ = [];
+  this.str = "";
 }
 
 function path() {
@@ -16,22 +16,22 @@ function path() {
 Path.prototype = path.prototype = {
   constructor: Path,
   moveTo: function(x, y) {
-    this._.push("M", this._x0 = this._x1 = +x, ",", this._y0 = this._y1 = +y);
+    this.str += "M" + (this._x0 = this._x1 = +x) + "," + (this._y0 = this._y1 = +y);
   },
   closePath: function() {
     if (this._x1 !== null) {
       this._x1 = this._x0, this._y1 = this._y0;
-      this._.push("Z");
+      this.str += "Z";
     }
   },
   lineTo: function(x, y) {
-    this._.push("L", this._x1 = +x, ",", this._y1 = +y);
+    this.str += "L" + (this._x1 = +x) + "," + (this._y1 = +y);
   },
   quadraticCurveTo: function(x1, y1, x, y) {
-    this._.push("Q", +x1, ",", +y1, ",", this._x1 = +x, ",", this._y1 = +y);
+    this.str += "Q" + (+x1) + "," + (+y1) + "," + (this._x1 = +x) + "," + (this._y1 = +y);
   },
   bezierCurveTo: function(x1, y1, x2, y2, x, y) {
-    this._.push("C", +x1, ",", +y1, ",", +x2, ",", +y2, ",", this._x1 = +x, ",", this._y1 = +y);
+    this.str += "C" + (+x1) + "," + (+y1) + "," + (+x2) + "," + (+y2) + "," + (this._x1 = +x) + "," + (this._y1 = +y);
   },
   arcTo: function(x1, y1, x2, y2, r) {
     x1 = +x1, y1 = +y1, x2 = +x2, y2 = +y2, r = +r;
@@ -48,9 +48,7 @@ Path.prototype = path.prototype = {
 
     // Is this path empty? Move to (x1,y1).
     if (this._x1 === null) {
-      this._.push(
-        "M", this._x1 = x1, ",", this._y1 = y1
-      );
+      this.str +=  "M" + (this._x1 = x1) + "," + (this._y1 = y1);
     }
 
     // Or, is (x1,y1) coincident with (x0,y0)? Do nothing.
@@ -60,9 +58,7 @@ Path.prototype = path.prototype = {
     // Equivalently, is (x1,y1) coincident with (x2,y2)?
     // Or, is the radius zero? Line to (x1,y1).
     else if (!(Math.abs(y01 * x21 - y21 * x01) > epsilon) || !r) {
-      this._.push(
-        "L", this._x1 = x1, ",", this._y1 = y1
-      );
+      this.str += "L" + (this._x1 = x1) + "," + (this._y1 = y1);
     }
 
     // Otherwise, draw an arc!
@@ -79,14 +75,11 @@ Path.prototype = path.prototype = {
 
       // If the start tangent is not coincident with (x0,y0), line to.
       if (Math.abs(t01 - 1) > epsilon) {
-        this._.push(
-          "L", x1 + t01 * x01, ",", y1 + t01 * y01
-        );
+        this.str += "L" + (x1 + t01 * x01) + "," + (y1 + t01 * y01);
       }
 
-      this._.push(
-        "A", r, ",", r, ",0,0,", +(y01 * x20 > x01 * y20), ",", this._x1 = x1 + t21 * x21, ",", this._y1 = y1 + t21 * y21
-      );
+      this.str +=
+        "A" + r + "," + r + ",0,0," + (+(y01 * x20 > x01 * y20)) + "," + (this._x1 = x1 + t21 * x21) + "," + (this._y1 = y1 + t21 * y21);
     }
   },
   arc: function(x, y, r, a0, a1, ccw) {
@@ -103,16 +96,12 @@ Path.prototype = path.prototype = {
 
     // Is this path empty? Move to (x0,y0).
     if (this._x1 === null) {
-      this._.push(
-        "M", x0, ",", y0
-      );
+      this.str +=  "M" + x0 + "," + y0;
     }
 
     // Or, is (x0,y0) not coincident with the previous point? Line to (x0,y0).
     else if (Math.abs(this._x1 - x0) > epsilon || Math.abs(this._y1 - y0) > epsilon) {
-      this._.push(
-        "L", x0, ",", y0
-      );
+      this.str += "L" + x0 + "," + y0;
     }
 
     // Is this arc empty? We’re done.
@@ -120,25 +109,25 @@ Path.prototype = path.prototype = {
 
     // Is this a complete circle? Draw two arcs to complete the circle.
     if (da > tauEpsilon) {
-      this._.push(
-        "A", r, ",", r, ",0,1,", cw, ",", x - dx, ",", y - dy,
-        "A", r, ",", r, ",0,1,", cw, ",", this._x1 = x0, ",", this._y1 = y0
-      );
+      this.str +=
+        "A" + r + "," + r + ",0,1," + cw + "," + (x - dx) + "," + (y - dy),
+        "A" + r + "," + r + ",0,1," + cw + "," + (this._x1 = x0) + "," + (this._y1 = y0);
     }
 
     // Otherwise, draw an arc!
     else {
       if (da < 0) da = da % tau + tau;
-      this._.push(
-        "A", r, ",", r, ",0,", +(da >= pi), ",", cw, ",", this._x1 = x + r * Math.cos(a1), ",", this._y1 = y + r * Math.sin(a1)
-      );
+      this.str +=
+        "A" + r + "," + r + ",0," + (+(da >= pi)) + "," + cw + "," +
+				(this._x1 = x + r * Math.cos(a1)) + "," + (this._y1 = y + r * Math.sin(a1));
     }
   },
   rect: function(x, y, w, h) {
-    this._.push("M", this._x0 = this._x1 = +x, ",", this._y0 = this._y1 = +y, "h", +w, "v", +h, "h", -w, "Z");
+    this.str += "M" + (this._x0 = this._x1 = +x) + "," + (this._y0 = this._y1 = +y) +
+		"h" + (+w) + "v" + (+h) + "h" + (-w) + "Z";
   },
   toString: function() {
-    return this._.join("");
+    return this.str;
   }
 };
 

--- a/src/path.js
+++ b/src/path.js
@@ -110,7 +110,7 @@ Path.prototype = path.prototype = {
     // Is this a complete circle? Draw two arcs to complete the circle.
     if (da > tauEpsilon) {
       this.str +=
-        "A" + r + "," + r + ",0,1," + cw + "," + (x - dx) + "," + (y - dy),
+        "A" + r + "," + r + ",0,1," + cw + "," + (x - dx) + "," + (y - dy) +
         "A" + r + "," + r + ",0,1," + cw + "," + (this._x1 = x0) + "," + (this._y1 = y0);
     }
 

--- a/test/path-test.js
+++ b/test/path-test.js
@@ -86,7 +86,7 @@ tape("path.arc(x, y, radius, startAngle, endAngle) may append only an L command 
 tape("path.arc(x, y, radius, startAngle, endAngle) may append an M command if the path was empty", function(test) {
   var p = path.path(); p.arc(100, 100, 50, 0, Math.PI * 2);
   test.pathEqual(p, "M150,100A50,50,0,1,1,50,100A50,50,0,1,1,150,100");
-  var p = path.path(); p.arc(0, 50, 50, -Math.PI / 2, 0);
+  p = path.path(); p.arc(0, 50, 50, -Math.PI / 2, 0);
   test.pathEqual(p, "M0,0A50,50,0,0,1,50,50");
   test.end();
 });
@@ -232,7 +232,7 @@ tape("path.arcTo(x1, y1, x2, y2, radius) appends an L command if the radius is z
 tape("path.arcTo(x1, y1, x2, y2, radius) appends L and A commands if the arc does not start at the current point", function(test) {
   var p = path.path(); p.moveTo(270, 182), p.arcTo(270, 39, 163, 100, 53);
   test.pathEqual(p, "M270,182L270,130.222686A53,53,0,0,0,190.750991,84.179342");
-  var p = path.path(); p.moveTo(270, 182), p.arcTo(270, 39, 363, 100, 53);
+  p = path.path(); p.moveTo(270, 182), p.arcTo(270, 39, 363, 100, 53);
   test.pathEqual(p, "M270,182L270,137.147168A53,53,0,0,1,352.068382,92.829799");
   test.end();
 });


### PR DESCRIPTION
String concatenation is significantly faster than array.join on almost every browser, and certainly in all of the modern ones (IE11, Chrome, FF, etc.)

JSPerf Performance Tests: https://jsperf.com/join-concat/2

Here is a a benchmark you can run of several different ways of executing the bezierCurveTo function.  The one in this pull request is the fastest (click the Results tab and then click Run Bench):
ESBench: https://esbench.com/bench/580e55ee330ab09900a1a351

This pull request modifies path to use string concatenation to do the same thing instead of array joining for about a 2x performance improvement.
