### PR TITLE
Detect coincident points when drawing arcs with rounding.

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -29,7 +29,7 @@ function equal(x0, y0, x1, y1) {
 
 function equalRound(digits) {
   const d = Math.floor(digits);
-  if (d > 15) return equal;
+  if (!(d <= 15)) return equal;
   const k = 10 ** d;
   const r = function(value) {
     return Math.round(value * k);
@@ -45,7 +45,7 @@ export class Path {
     this._x1 = this._y1 = null; // end of current subpath
     this._ = "";
     this._append = digits == null ? append : appendRound(digits);
-    this._equal = digits === null ? equal : equalRound(digits);
+    this._equal = digits == null ? equal : equalRound(digits);
   }
   moveTo(x, y) {
     this._append`M${this._x0 = this._x1 = +x},${this._y0 = this._y1 = +y}`;

--- a/src/path.js
+++ b/src/path.js
@@ -38,6 +38,7 @@ function equalRound(digits) {
     return r(x0) === r(x1) && r(y0) === r(y1);
   };
 }
+
 export class Path {
   constructor(digits) {
     this._x0 = this._y0 = // start of current subpath

--- a/src/path.js
+++ b/src/path.js
@@ -23,26 +23,21 @@ function appendRound(digits) {
   };
 }
 
-function round(digits) {
-  const k = 10 ** digits;
-  return function(value) {
-    return Math.round(value * k) / k;
-  };
-}
-
 function equal(x0, y0, x1, y1) {
   return x0 === x1 && y0 === y1;
 }
 
 function equalRound(digits) {
-  let d = Math.floor(digits);
+  const d = Math.floor(digits);
   if (d > 15) return equal;
-  const r = round(digits);
+  const k = 10 ** d;
+  const r = function(value) {
+    return Math.round(value * k);
+  };
   return function(x0, y0, x1, y1) {
     return r(x0) === r(x1) && r(y0) === r(y1);
   };
 }
-
 export class Path {
   constructor(digits) {
     this._x0 = this._y0 = // start of current subpath

--- a/test/pathRound-test.js
+++ b/test/pathRound-test.js
@@ -50,6 +50,29 @@ it("pathRound.arc(x, y, r, a0, a1, ccw) limits the precision", () => {
   assert.strictEqual(p + "", precision(p0 + "", 1));
 });
 
+it("pathRound.arc(x, y, r, a0, a1, false) draws two arcs for near-circular arcs with rounding", () => {
+  const p0 = path(), p = pathRound(1);
+  const a0 = -1.5707963267948966;
+  const a1 = 4.712383653719071;
+  const a00 = a0 + (a1 - a0) / 2;
+  p0.arc(0, 0, 75, a0, a00);
+  p0.arc(0, 0, 75, a00, a1);
+  p.arc(0, 0, 75, a0, a1);
+  assert.strictEqual(p + "", precision(p0 + "", 1));
+});
+
+it("pathRound.arc(x, y, r, a0, a1, true) draws two arcs for near-circular arcs with rounding", () => {
+  const p0 = path(), p = pathRound(1);
+  const a0 = 0;
+  const a1 = a0 + 1e-5;
+  const da = 2 * Math.PI - 1e-5;
+  const a00 = a0 - da / 2;
+  p0.arc(0, 0, 75, a0, a00, true);
+  p0.arc(0, 0, 75, a00, a1, true);
+  p.arc(0, 0, 75, a0, a1, true);
+  assert.strictEqual(p + "", precision(p0 + "", 1));
+});
+
 it("pathRound.arcTo(x1, y1, x2, y2, r) limits the precision", () => {
   const p0 = path(), p = pathRound(1);
   p0.arcTo(10.0001, 10.0001, 123.456, 456.789, 12345.6789);
@@ -79,5 +102,5 @@ it("pathRound.rect(x, y, w, h) limits the precision", () => {
 });
 
 function precision(str, precision) {
-  return str.replace(/\d+\.\d+/g, s => +parseFloat(s).toFixed(precision));
+  return str.replace(/-?\d+\.\d+(e-?\d+)?/g, s => +parseFloat(s).toFixed(precision));
 }


### PR DESCRIPTION
When rounding is used, it's possible for `arc()` to generate empty arcs in the case where the start and end points are almost coincident, and become coincident after rounding is applied.

This adds a check for coincident points after rounding is applied, and splits the arc into two if coincident points are detected.

Fixes #38.